### PR TITLE
Added support for CocoaPods

### DIFF
--- a/MGSplitViewController.podspec
+++ b/MGSplitViewController.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/tafax/MGSplitViewController"
   s.license      = "BSD"
   s.author             = { "Matteo Tafani Alunno" => "mtafanialunno@vendini.com" }
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "5.0"
   s.source       = { :git => "https://github.com/tafax/MGSplitViewController.git", :tag => 'v1.0.0' }
   s.source_files  = "Classes", "Classes/**/*.{h,m}"
   s.exclude_files = "Classes/Exclude"


### PR DESCRIPTION
If order to manage only one repository, it should be merged with the repo used as a reference for out projects.
