### PR TITLE
Prevent crash when trying to add nil to an array

### DIFF
--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -151,7 +151,7 @@
 {
 	_delegate = nil;
 	self.masterViewController = nil;
-	self.detailViewController = nil;
+	self.detailViewController = [NSNull null];
 	[self.view.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
 }
 

--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -150,8 +150,7 @@
 - (void)dealloc
 {
 	_delegate = nil;
-	self.masterViewController = nil;
-	self.detailViewController = [NSNull null];
+    _viewControllers = nil;
 	[self.view.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
 }
 

--- a/MGSplitView.xcodeproj/project.xcworkspace/xcshareddata/MGSplitView.xccheckout
+++ b/MGSplitView.xcodeproj/project.xcworkspace/xcshareddata/MGSplitView.xccheckout
@@ -11,17 +11,17 @@
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>5033EDB6B36AFC1F9AB7153D494FDE66318C7E8E</key>
-		<string>https://github.com/asprega/MGSplitViewController.git</string>
+		<string>github.com:sebastianwr/MGSplitViewController.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>MGSplitView.xcodeproj/project.xcworkspace</string>
+	<string>MGSplitView.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>5033EDB6B36AFC1F9AB7153D494FDE66318C7E8E</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/asprega/MGSplitViewController.git</string>
+	<string>github.com:sebastianwr/MGSplitViewController.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>


### PR DESCRIPTION
When dealloc'ing the MGSplitViewController, the setter tries to insert nil into the array. To avoid this, the null object is used.